### PR TITLE
fix null string check for C++ using thrift api

### DIFF
--- a/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
+++ b/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HiveMetaStore.java
@@ -6721,7 +6721,7 @@ public class HiveMetaStore extends ThriftHiveMetastore {
         if (dbName == null) {
           return getMS().listPrincipalTableGrantsAll(principalName, principalType);
         }
-        if (principalName == null) {
+        if (StringUtil.isNullOrEmpty(principalName)) {
           return getMS().listTableGrantsAll(catName, dbName, tableName);
         }
         return getMS().listAllTableGrants(principalName, principalType, catName, dbName, tableName);


### PR DESCRIPTION
thrift generate C++ files, using (std::string& principalName) as list_privileges parameters. When it only checks null in java code, null string can not be passed by C++ api only if generated source code is modified. 
api in generated ThriftHiveMetastore.h is:
void list_privileges(std::vector<HiveObjectPrivilege> & _return, const std::string& principal_name, const PrincipalType::type principal_type, const HiveObjectRef& hiveObject);